### PR TITLE
Added kube-system directory for chaos environment

### DIFF
--- a/namespaces/test-2.k8s.cloud-platform.dsd.io/kube-system/00-namespace.yaml
+++ b/namespaces/test-2.k8s.cloud-platform.dsd.io/kube-system/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-system

--- a/namespaces/test-2.k8s.cloud-platform.dsd.io/kube-system/concourse-build-environments.yaml
+++ b/namespaces/test-2.k8s.cloud-platform.dsd.io/kube-system/concourse-build-environments.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: concourse-build-environments
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: concourse-build-environments
+subjects:
+- kind: ServiceAccount
+  name: concourse-build-environments
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
For our chaos engineering, we will need to replicate our environments repo.

This PR is just a replication of our environments kube system directory. This defines the kube system namespace and the serviceaccount for concourse. Will need this merged so that concourse can gain access to our test-2 cluster